### PR TITLE
Fixed typo

### DIFF
--- a/MQ135.cpp
+++ b/MQ135.cpp
@@ -24,8 +24,7 @@ v1.0 - First release
 */
 /**************************************************************************/
 
-MQ135::MQ135(uint8_t pin) {
-  _pin = pin;
+MQ135::MQ135(uint8_t pin) : _pin(pin){
 }
 /**************************************************************************/
 /*!
@@ -34,7 +33,7 @@ MQ135::MQ135(uint8_t pin) {
 @return The sensor resistance in Ohms
 */
 /**************************************************************************/
-float MQ135::getResistance() {
+float MQ135::getResistance() const {
   int val = analogRead(_pin);
   /*
   * Values from @lorf
@@ -49,7 +48,7 @@ float MQ135::getResistance() {
 @return ppm value of CO in air
 */
 /**************************************************************************/
-float MQ135::getCOPPM() {
+float MQ135::getCOPPM() const {
   return scaleFactorCO * pow((getResistance()/r0CO), -exponentCO);
 }
 /**************************************************************************/
@@ -59,7 +58,7 @@ float MQ135::getCOPPM() {
 @return The ppm of CO2 in the air
 */
 /**************************************************************************/
-float MQ135::getCO2PPM() {
+float MQ135::getCO2PPM() const {
   return scaleFactorCO2 * pow((getResistance()/r0CO2), -exponentCO2);
 }
 /**************************************************************************/
@@ -69,7 +68,7 @@ float MQ135::getCO2PPM() {
 @return The ppm of Ethanol in the air
 */
 /**************************************************************************/
-float MQ135::getEthanolPPM() {
+float MQ135::getEthanolPPM() const {
   return scaleFactorEthanol * pow((getResistance()/r0Ethanol), -exponentEthanol);
 }
 /**************************************************************************/
@@ -79,7 +78,7 @@ float MQ135::getEthanolPPM() {
 @return The ppm of NH4 in the air
 */
 /**************************************************************************/
-float MQ135::getNH4PPM() {
+float MQ135::getNH4PPM() const {
   return scaleFactorNH4 * pow((getResistance()/r0NH4), -exponentNH4);
 }
 /**************************************************************************/
@@ -89,7 +88,7 @@ float MQ135::getNH4PPM() {
 @return The ppm of CO2 in the air
 */
 /**************************************************************************/
-float MQ135::getToluenePPM() {
+float MQ135::getToluenePPM() const {
   return scaleFactorToluene * pow((getResistance()/r0Toluene), -exponentToluene);
 }
 /**************************************************************************/
@@ -99,7 +98,7 @@ float MQ135::getToluenePPM() {
 @return The ppm of CO2 in the air
 */
 /**************************************************************************/
-float MQ135::getAcetonePPM() {
+float MQ135::getAcetonePPM() const {
   return scaleFactorAcetone * pow((getResistance()/r0Acetone), -exponentAcetone);
 }
 /**************************************************************************/
@@ -109,7 +108,7 @@ float MQ135::getAcetonePPM() {
 @return The sensor resistance RZero in kOhm
 */
 /**************************************************************************/
-float MQ135::getRZeroCO() {
+float MQ135::getRZeroCO() const {
   return getResistance() * pow((atmCO/scaleFactorCO), (1./exponentCO));
 }
 /**************************************************************************/
@@ -119,7 +118,7 @@ float MQ135::getRZeroCO() {
 @return The sensor resistance RZero in kOhm
 */
 /**************************************************************************/
-float MQ135::getRZeroCO2() {
+float MQ135::getRZeroCO2() const {
   return getResistance() * pow((atmCO2/scaleFactorCO2), (1./exponentCO2));
 }
 /**************************************************************************/
@@ -129,7 +128,7 @@ float MQ135::getRZeroCO2() {
 @return The sensor resistance RZero in kOhm
 */
 /**************************************************************************/
-float MQ135::getRZeroEthanol() {
+float MQ135::getRZeroEthanol() const {
   return getResistance() * pow((atmEthanol/scaleFactorEthanol), (1./exponentEthanol));
 }
 /**************************************************************************/
@@ -139,7 +138,7 @@ float MQ135::getRZeroEthanol() {
 @return The sensor resistance RZero in kOhm
 */
 /**************************************************************************/
-float MQ135::getRZeroNH4() {
+float MQ135::getRZeroNH4() const {
   return getResistance() * pow((atmNH4/scaleFactorNH4), (1./exponentNH4));
 }
 /**************************************************************************/
@@ -149,7 +148,7 @@ float MQ135::getRZeroNH4() {
 @return The sensor resistance RZero in kOhm
 */
 /**************************************************************************/
-float MQ135::getRZeroToluene() {
+float MQ135::getRZeroToluene() const {
   return getResistance() * pow((atmToluene/scaleFactorToluene), (1./exponentToluene));
 }
 /**************************************************************************/
@@ -159,7 +158,7 @@ float MQ135::getRZeroToluene() {
 @return The sensor resistance RZero in kOhm
 */
 /**************************************************************************/
-float MQ135::getRZeroAcetone() {
+float MQ135::getRZeroAcetone() const {
   return getResistance() * pow((atmAcetone/scaleFactorAcetone), (1./exponentAcetone));
 }
 /**************************************************************************/
@@ -168,7 +167,7 @@ float MQ135::getRZeroAcetone() {
 @return ppm value of CO in air
 */
 /**************************************************************************/
-float MQ135::getCO(float res) {
+float MQ135::getCO(float res) const {
   return scaleFactorCO * pow((res/r0CO), -exponentCO);
 }
 /**************************************************************************/
@@ -178,7 +177,7 @@ float MQ135::getCO(float res) {
 @return The ppm of CO2 in the air
 */
 /**************************************************************************/
-float MQ135::getCO2(float res) {
+float MQ135::getCO2(float res) const {
   return scaleFactorCO2 * pow((res/r0CO2), -exponentCO2);
 }
 /**************************************************************************/
@@ -188,7 +187,7 @@ float MQ135::getCO2(float res) {
 @return The ppm of Ethanol in the air
 */
 /**************************************************************************/
-float MQ135::getEthanol(float res) {
+float MQ135::getEthanol(float res) const {
   return scaleFactorEthanol * pow((res/r0Ethanol), -exponentEthanol);
 }
 /**************************************************************************/
@@ -198,7 +197,7 @@ float MQ135::getEthanol(float res) {
 @return The ppm of NH4 in the air
 */
 /**************************************************************************/
-float MQ135::getNH4(float res) {
+float MQ135::getNH4(float res) const {
   return scaleFactorNH4 * pow((res/r0NH4), -exponentNH4);
 }
 /**************************************************************************/
@@ -208,7 +207,7 @@ float MQ135::getNH4(float res) {
 @return The ppm of CO2 in the air
 */
 /**************************************************************************/
-float MQ135::getToluene(float res) {
+float MQ135::getToluene(float res) const {
   return scaleFactorToluene * pow((res/r0Toluene), -exponentToluene);
 }
 /**************************************************************************/
@@ -218,52 +217,52 @@ float MQ135::getToluene(float res) {
 @return The ppm of CO2 in the air
 */
 /**************************************************************************/
-float MQ135::getAcetone(float res) {
+float MQ135::getAcetone(float res) const {
   return scaleFactorAcetone * pow((res/r0Acetone), -exponentAcetone);
 }
 /* RETURN THE RZERO WITH A PARAMETER OF RESISTANCE*/
-float MQ135::getCorrectedRZero(float r) {
+float MQ135::getCorrectedRZero(float r) const {
   return r * pow((atmCO2/scaleFactorCO2), (1./exponentCO2));
 }
-float MQ135::getCorrectedRZeroCO(float r) {
+float MQ135::getCorrectedRZeroCO(float r) const {
   return r * pow((atmCO/scaleFactorCO), (1./exponentCO));
 }
-float MQ135::getCorrectedRZeroEthanol(float r) {
+float MQ135::getCorrectedRZeroEthanol(float r) const {
   return r * pow((atmEthanol/scaleFactorEthanol), (1./exponentEthanol));
 }
-float MQ135::getCorrectedRZeroNH4(float r) {
+float MQ135::getCorrectedRZeroNH4(float r) const {
   return r * pow((atmNH4/scaleFactorNH4), (1./exponentNH4));
 }
-float MQ135::getCorrectedRZeroToluene(float r) {
+float MQ135::getCorrectedRZeroToluene(float r) const {
   return r * pow((atmToluene/scaleFactorToluene), (1./exponentToluene));
 }
-float MQ135::getCorrectedRZeroAcetone(float r) {
+float MQ135::getCorrectedRZeroAcetone(float r) const {
   return r * pow((atmAcetone/scaleFactorAcetone), (1./exponentAcetone));
 }
 /*CORRECTED RESISTANCE*/
-float MQ135::getCorrectedResistance(float t, float h) {
+float MQ135::getCorrectedResistance(float t, float h) const {
   return getResistance()/getCorrectionFactor(t, h);
 }
 /*CORRECTION FACTOR*/
-float MQ135::getCorrectionFactor(float t, float h) {
+float MQ135::getCorrectionFactor(float t, float h) const {
   return CORA * t * t - CORB * t + CORC - (h-33.)*CORD;
 }
 
-float MQ135::getCalibratedCO2(float t, float h){
+float MQ135::getCalibratedCO2(float t, float h) const {
   return scaleFactorCO2 * pow((getCorrectedResistance(t, h)/getCorrectedRZero(getCorrectedResistance(t, h))), -exponentCO2);
 }
-float MQ135::getCalibratedCO(float t, float h) {
+float MQ135::getCalibratedCO(float t, float h) const {
   return scaleFactorCO * pow((getCorrectedResistance(t, h)/getCorrectedRZeroCO(getCorrectedResistance(t, h))), -exponentCO);
 }
-float MQ135::getCalibratedEthanol(float t, float h) {
+float MQ135::getCalibratedEthanol(float t, float h) const {
   return scaleFactorEthanol * pow((getCorrectedResistance(t, h)/getCorrectedRZeroEthanol(getCorrectedResistance(t, h))), -exponentEthanol);
 }
-float MQ135::getCalibratedNH4(float t, float h) {
+float MQ135::getCalibratedNH4(float t, float h) const {
   return scaleFactorNH4 * pow((getCorrectedResistance(t, h)/getCorrectedRZeroNH4(getCorrectedResistance(t, h))), -exponentNH4);
 }
-float MQ135::getCalibratedToluene(float t, float h) {
+float MQ135::getCalibratedToluene(float t, float h) const {
   return scaleFactorToluene * pow((getCorrectedResistance(t, h)/getCorrectedRZeroToluene(getCorrectedResistance(t, h))), -exponentToluene);
 }
-float MQ135::getCalibratedAcetone(float t, float h) {
+float MQ135::getCalibratedAcetone(float t, float h) const {
   return scaleFactorAcetone * pow((getCorrectedResistance(t, h)/getCorrectedRZeroAcetone(getCorrectedResistance(t, h))), -exponentAcetone);
 }

--- a/MQ135.cpp
+++ b/MQ135.cpp
@@ -26,6 +26,17 @@ v1.0 - First release
 
 MQ135::MQ135(uint8_t pin) : _pin(pin){
 }
+
+
+/**************************************************************************/
+/*!
+@brief  Set up the pins!
+*/
+/**************************************************************************/
+void MQ135::begin()
+{ 
+  pinMode(_pin, INPUT);
+}
 /**************************************************************************/
 /*!
 @brief  Get the resistance of the sensor, ie. the measurement value
@@ -40,7 +51,7 @@ float MQ135::getResistance() const {
   * r = ((1023. * _rload * _vc) / ((float)val * _vref)) - _rload;
   *
   */
-  return ((1023. * RLOAD * 5)/((float)val * 5)) - RLOAD;
+  return ((1023. * RLOAD * 5.)/((float)val * 5.)) - RLOAD;
 }
 /**************************************************************************/
 /*!

--- a/MQ135.h
+++ b/MQ135.h
@@ -73,12 +73,16 @@ v1.0 - First release
 /// Atmospheric Acetone level for calibration purposes
 #define atmAcetone 16
 
+
 class MQ135 {
  private:
   const uint8_t _pin;
 
  public:
   MQ135(uint8_t pin);
+
+  void begin();
+
   float getResistance() const;
   
   float getCOPPM() const;

--- a/MQ135.h
+++ b/MQ135.h
@@ -75,50 +75,50 @@ v1.0 - First release
 
 class MQ135 {
  private:
-  uint8_t _pin;
+  const uint8_t _pin;
 
  public:
   MQ135(uint8_t pin);
-  float getResistance();
+  float getResistance() const;
   
-  float getCOPPM();
-  float getCO2PPM();
-  float getEthanolPPM();
-  float getNH4PPM();
-  float getToluenePPM();
-  float getAcetonePPM();
+  float getCOPPM() const;
+  float getCO2PPM() const;
+  float getEthanolPPM() const;
+  float getNH4PPM() const;
+  float getToluenePPM() const;
+  float getAcetonePPM() const;
   
-  float getRZeroCO();
-  float getRZeroCO2();
-  float getRZeroEthanol();
-  float getRZeroNH4();
-  float getRZeroToluene();
-  float getRZeroAcetone();
+  float getRZeroCO() const;
+  float getRZeroCO2() const;
+  float getRZeroEthanol() const;
+  float getRZeroNH4() const;
+  float getRZeroToluene() const;
+  float getRZeroAcetone() const;
   
-  float getCO(float res);
-  float getCO2(float res);
-  float getEthanol(float res);
-  float getNH4(float res);
-  float getToluene(float res);
-  float getAcetone(float res);
+  float getCO(float res) const;
+  float getCO2(float res) const;
+  float getEthanol(float res) const;
+  float getNH4(float res) const;
+  float getToluene(float res) const;
+  float getAcetone(float res) const;
   
   
-  float getCorrectedRZero(float r);
-  float getCorrectedRZeroCO(float r);
-  float getCorrectedRZeroEthanol(float r);
-  float getCorrectedRZeroNH4(float r);
-  float getCorrectedRZeroToluene(float r);
-  float getCorrectedRZeroAcetone(float r);
+  float getCorrectedRZero(float r) const;
+  float getCorrectedRZeroCO(float r) const;
+  float getCorrectedRZeroEthanol(float r) const;
+  float getCorrectedRZeroNH4(float r) const;
+  float getCorrectedRZeroToluene(float r) const;
+  float getCorrectedRZeroAcetone(float r) const;
   
-  float getCorrectedResistance(float t, float h);
-  float getCorrectionFactor(float t, float h);
+  float getCorrectedResistance(float t, float h) const;
+  float getCorrectionFactor(float t, float h) const;
   
-  float getCalibratedCO2(float t, float h);
-  float getCalibratedCO(float t, float h);
-  float getCalibratedEthanol(float t, float h);
-  float getCalibratedNH4(float t, float h);
-  float getCalibratedToluene(float t, float h);
-  float getCalibratedAcetone(float t, float h);
+  float getCalibratedCO2(float t, float h) const;
+  float getCalibratedCO(float t, float h) const;
+  float getCalibratedEthanol(float t, float h) const;
+  float getCalibratedNH4(float t, float h) const;
+  float getCalibratedToluene(float t, float h) const;
+  float getCalibratedAcetone(float t, float h) const;
 
 
 };

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ First you need the resistance zero, leave the sensor connected 24hrs outside and
 Call them with 
 
 > ```
-float resistanceZero = mqSensor.getRZeroC0();
+float resistanceZero = mqSensor.getRZeroCO();
 ```
 
 Change the resistance zero in 


### PR DESCRIPTION
If someone c&p from the README file, he'd get a "getRZeroC0() doesn't exist in class MQ135".